### PR TITLE
Add simple spanish rules

### DIFF
--- a/inflect.go
+++ b/inflect.go
@@ -24,6 +24,7 @@ type Ruleset struct {
 	singulars      []*Rule
 	humans         []*Rule
 	acronyms       []*Rule
+	defaultEnd     string
 	acronymMatcher *regexp.Regexp
 }
 
@@ -38,6 +39,7 @@ func NewRuleset() *Ruleset {
 	rs.singulars = make([]*Rule, 0)
 	rs.humans = make([]*Rule, 0)
 	rs.acronyms = make([]*Rule, 0)
+	rs.defaultEnd = ""
 	return rs
 }
 
@@ -45,6 +47,7 @@ func NewRuleset() *Ruleset {
 // set of common English pluralization rules
 func NewDefaultRuleset() *Ruleset {
 	rs := NewRuleset()
+	rs.defaultEnd = "s"
 	rs.AddPlural("s", "s")
 	rs.AddPlural("testis", "testes")
 	rs.AddPlural("axis", "axes")
@@ -352,7 +355,7 @@ func (rs *Ruleset) Pluralize(word string) string {
 			}
 		}
 	}
-	return word + "s"
+	return word + rs.defaultEnd
 }
 
 // Singularize returns the singular form of a plural word

--- a/inflect_es.go
+++ b/inflect_es.go
@@ -1,0 +1,45 @@
+package inflect
+
+// NewSpanishRuleset creates a simplified version of the grammar rules
+// probably enough for database tables names that are written in spanish without tonic accents
+// For an exhaustive ruleset you would need to detect the word's toinic sylables
+// https://espanol.lingolia.com/es/gramatica/sustantivos-articulos/plural
+func NewSpanishRuleset() *Ruleset {
+	rs := NewRuleset()
+
+	rs.AddPlural("í", "íes")
+	rs.AddPlural("ú", "úes")
+	rs.AddPlural("d", "des")
+	rs.AddPlural("j", "jes")
+	rs.AddPlural("l", "les")
+	rs.AddPlural("n", "nes")
+	rs.AddPlural("r", "res")
+	rs.AddPlural("z", "ces")
+
+	rs.AddPlural("a", "as")
+	rs.AddPlural("e", "es")
+	rs.AddPlural("i", "is")
+	rs.AddPlural("o", "os")
+	rs.AddPlural("u", "us")
+
+	//
+
+	rs.AddSingular("us", "u")
+	rs.AddSingular("os", "o")
+	rs.AddSingular("is", "i")
+	rs.AddSingular("es", "e")
+	rs.AddSingular("as", "a")
+
+	rs.AddSingular("ces", "z")
+	rs.AddSingular("res", "r")
+	rs.AddSingular("nes", "n")
+	rs.AddSingular("les", "l")
+	rs.AddSingular("jes", "j")
+	rs.AddSingular("des", "d")
+	rs.AddSingular("úes", "ú")
+	rs.AddSingular("íes", "í")
+
+	//english consonnat ending words
+
+	return rs
+}

--- a/inflect_es_test.go
+++ b/inflect_es_test.go
@@ -1,0 +1,48 @@
+package inflect
+
+import (
+	"testing"
+)
+
+var SingularToPluralES = map[string]string{
+	"libro":     "libros",
+	"mesa":      "mesas",
+	"jabalí":    "jabalíes",
+	"bambú":     "bambúes",
+	"ordenador": "ordenadores",
+	"reloj":     "relojes",
+	"cruz":      "cruces",
+	"elefante":  "elefantes",
+	"manzana":   "manzanas",
+	//"club":      "clubes", this fails under our simlpe model
+}
+
+var ES = NewSpanishRuleset()
+
+func TestPluralizeSingularES(t *testing.T) {
+	for singular, plural := range SingularToPluralES {
+		assertEqual(t, plural, ES.Pluralize(singular))
+		assertEqual(t, ES.Capitalize(plural), ES.Capitalize(ES.Pluralize(singular)))
+	}
+}
+
+func TestSingularizePluralES(t *testing.T) {
+	for singular, plural := range SingularToPluralES {
+		assertEqual(t, singular, ES.Singularize(plural))
+		assertEqual(t, ES.Capitalize(singular), ES.Capitalize(ES.Singularize(plural)))
+	}
+}
+
+func TestPluralizePluralES(t *testing.T) {
+	for _, plural := range SingularToPluralES {
+		assertEqual(t, plural, ES.Pluralize(plural))
+		assertEqual(t, ES.Capitalize(plural), ES.Capitalize(ES.Pluralize(plural)))
+	}
+}
+
+func TestSingularizeSingularES(t *testing.T) {
+	for singular := range SingularToPluralES {
+		assertEqual(t, singular, ES.Singularize(singular))
+		assertEqual(t, ES.Capitalize(singular), ES.Capitalize(ES.Singularize(singular)))
+	}
+}


### PR DESCRIPTION
Add basic spanish rules to inflect.
No chage to api or existing ruleset.
change in inflect.go is to make the default case ending variable.